### PR TITLE
don't force our own copy of jquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/mg50/mathquill-webpack-integration.git"
   },
   "dependencies": {
-    "jquery": "latest",
-    "mathquill": "latest"
+    "jquery": ">= 1",
+    "mathquill": ">= 0.10.1"
   }
 }


### PR DESCRIPTION
because these were set to "latest" it was forcing yarn to use a separate version of
 jquery just for this in gauge. so if you look at the admin bundle in gauge. because 
mathquill, and everything else wants a jquery 1.x, but latest would tell yarn to try to 
use jquery@3.x for it. 

so to get this fixed so gauge's admin bundle is smaller we need to:
1. merge this change
2. publish a new version of this to npm
3. `yarn upgrade mathquill-webpack-integration` in quiz-interactions
4. publish a new version of quiz-interactions
5. use that new version of quiz-interactions in gauge